### PR TITLE
letter-pro file in README now matches actually released file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,15 @@ Then import the package in your document:
 ```
 
 ### Manual
-Download the ``letter-pro-v2.0.0.typ`` file from the [releases page](https://github.com/Sematre/typst-letter-pro/releases) and place it next to your document file.
+Download the ``typst-letter-pro-v2.0.0.typ`` file from the [releases page](https://github.com/Sematre/typst-letter-pro/releases) and place it next to your document file, e.g., using *wget*:
+
+```bash
+wget https://github.com/Sematre/typst-letter-pro/releases/download/v2.0.0/typst-letter-pro-v2.0.0.typ
+```
 
 Then import the package in your document:
 ```typst
-#import "letter-pro-v2.0.0.typ": letter-simple
+#import "typst-letter-pro-v2.0.0.typ": letter-simple
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ Then import the package in your document:
 ```
 
 ### Manual
-Download the ``typst-letter-pro-v2.0.0.typ`` file from the [releases page](https://github.com/Sematre/typst-letter-pro/releases) and place it next to your document file, e.g., using *wget*:
+Download the ``letter-pro-v2.0.0.typ`` file from the [releases page](https://github.com/Sematre/typst-letter-pro/releases) and place it next to your document file, e.g., using *wget*:
 
 ```bash
-wget https://github.com/Sematre/typst-letter-pro/releases/download/v2.0.0/typst-letter-pro-v2.0.0.typ
+wget https://github.com/Sematre/typst-letter-pro/releases/download/v2.0.0/letter-pro-v2.0.0.typ
 ```
 
 Then import the package in your document:
 ```typst
-#import "typst-letter-pro-v2.0.0.typ": letter-simple
+#import "letter-pro-v2.0.0.typ": letter-simple
 ```
 
 ## Contributing


### PR DESCRIPTION
The name of the typst-letter-pro-v2.0.0.typ file on the releases page did not match the documented name in the readme.

Also, added a one-liner to download that file with *wget*.