### PR TITLE
Sender name is mandatory in `letter-simple`

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -534,10 +534,17 @@
   )
   
   // Configure page and text properties.
-  set document(
-    title: subject,
-    author: sender.name,
-  )
+  if sender.name != none {
+    set document(
+      title: subject,
+      author: sender.name
+    )
+  }
+  else {
+    set document(
+      title: subject,
+    )
+  }
 
   set text(font: font, hyphenate: false)
 


### PR DESCRIPTION
Fixes https://github.com/Sematre/typst-letter-pro/issues/21