### PR TITLE
More generic access of current page counter suitable for counter reset

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -163,7 +163,7 @@
     footer: context {
       show: pad.with(top: 12pt, bottom: 12pt)
       
-      let current-page = here().page()
+      let current-page = counter(page).get().first()
       let page-count = counter(page).final().first()
       
       grid(


### PR DESCRIPTION
This can be used if several letters are created in a loop, e.g., a form letter, and the page counter needs to be reset for each letter.