### PR TITLE
Optionally surpressed set document(...) calls to allow for multiple letters from one document.

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -437,6 +437,8 @@
 ///   
 ///   The name and address fields must be strings (or none).
 /// 
+/// - disable-document-properties (boolean): If enabled, the document properties will not be set. Use for generating multiple letters from a single document.
+/// 
 /// - recipient (content, none): The recipient that will be displayed below the annotations.
 /// 
 /// - stamp (boolean): This will increase the annotations box size is by two lines in order to provide more room for the postage stamp that will be displayed below the sender.
@@ -501,7 +503,9 @@
     address: none,
     extra: none,
   ),
-  
+
+  disable-document-properties: false,
+
   recipient: none,
 
   stamp: false,
@@ -534,13 +538,13 @@
   )
   
   // Configure page and text properties.
-  if sender.name != none {
+  if sender.name != none and not disable-document-properties {
     set document(
       title: subject,
       author: sender.name
     )
   }
-  else {
+  else if not disable-document-properties {
     set document(
       title: subject,
     )


### PR DESCRIPTION
When generating more than one letter from the same document, this call will inevitably fail. A set document(...) call must be before any content. On repeated calls of letter-simple(...), the content of the first calls will be in front of the set document(...) calls of the later function calls.
To make generating multiple letters from the same document a possibility while retaining current functionality, an optional parameter disable-document-properties is introduced, which will inhibit set document(...) calls when set to true.
Documentation is added to reflect this addition.

Kindly review this change and inform me of any shortcomings of my contribution that still needs to be addressed.
I am a first time contributor here and would love the feedback!
Be excellent to each other.