### PR TITLE
feature: add custom background to letter

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -98,6 +98,8 @@
   
   header: none,
   footer: none,
+
+  background: none,
   
   folding-marks: true,
   hole-mark: true,
@@ -134,8 +136,10 @@
     flipped: false,
     
     margin: margin,
-    
+
     background: {
+        background
+
       if folding-marks {
         // folding mark 1
         place(top + left, dx: 5mm, dy: letter-formats.at(format).folding-mark-1-pos, line(
@@ -493,6 +497,8 @@
   header: auto,
   footer: none,
 
+  background: none,
+
   folding-marks: true,
   hole-mark: true,
   
@@ -580,6 +586,8 @@
     
     header: header,
     footer: footer,
+
+    background: background,
 
     folding-marks: folding-marks,
     hole-mark: hole-mark,


### PR DESCRIPTION
This PR addresses #19 such that a background could be added.

This is possible like this:

```
#show: letter-simple.with(
  background: image("bg.svg"), // <- Here :-)
  sender: (
    name: "Anja Ahlsen",
    address: "Eiersalatweg 28, 60528 Frankfurt",
    extra: [
      Telefon: #link("tel:+4915228817386")[+49 152 28817386]\
      E-Mail: #link("mailto:aahlsen@example.com")[aahlsen\@example.com]\
    ],
  ),
  ...
 ```

Or also like this with a DRAFT mark:

```
#show: letter-simple.with(
  background: rotate(
      45deg,
      text(
         5em,
         fill: gray
      )[DRAFT]
   ),
  sender: (
    name: "Anja Ahlsen",
    address: "Eiersalatweg 28, 60528 Frankfurt",
    extra: [
      Telefon: #link("tel:+4915228817386")[+49 152 28817386]\
      E-Mail: #link("mailto:aahlsen@example.com")[aahlsen\@example.com]\
    ],
  ),
  ...
 ```