### PR TITLE
Sender Address

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -98,6 +98,8 @@
   
   header: none,
   footer: none,
+
+  background: none,
   
   folding-marks: true,
   hole-mark: true,
@@ -134,8 +136,10 @@
     flipped: false,
     
     margin: margin,
-    
+
     background: {
+        background
+
       if folding-marks {
         // folding mark 1
         place(top + left, dx: 5mm, dy: letter-formats.at(format).folding-mark-1-pos, line(
@@ -493,6 +497,8 @@
   header: auto,
   footer: none,
 
+  background: none,
+
   folding-marks: true,
   hole-mark: true,
   
@@ -580,6 +586,8 @@
     
     header: header,
     footer: footer,
+
+    background: background,
 
     folding-marks: folding-marks,
     hole-mark: hole-mark,


### PR DESCRIPTION
According to DIN-5008-A and DIN-5008-B the sender field is 5mm below the
header size. This commit fixes this and makes the template more standard
compliant.