### PR TITLE
fix: sender address

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -553,10 +553,10 @@
     header = pad(
       left:   margin.left,
       right:  margin.right,
-      top:    margin.top,
+      top:    letter-formats.at(format).header-size + 5mm,
       bottom: 5mm,
       
-      align(bottom + right, header-simple(
+      align(top + right, header-simple(
         sender.name,
         if sender.address != none {
           sender.address.split(", ").join(linebreak())


### PR DESCRIPTION
According to DIN-5008-A and DIN-5008-B the sender field is 5mm below the
header size. This commit fixes this and makes the template more standard
compliant.