### PR TITLE
Fall back to document metadata

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -510,7 +510,7 @@
   information-box: none,
   reference-signs: none,
   
-  date: none,
+  date: auto,
   subject: none,
 
   page-numbering: auto,
@@ -534,16 +534,25 @@
   )
   
   // Configure page and text properties.
-  if sender.name != none {
-    set document(
-      title: subject,
-      author: sender.name
-    )
+  if subject != none {
+    set document(title: subject)
+  } else {
+    subject = context document.title;
   }
-  else {
-    set document(
-      title: subject,
-    )
+  if sender.at("name", default: none) != none {
+    set document(author: sender.name)
+  } else {
+    sender.name = context document.author.at(0);
+  }
+  if date == auto {
+     date = context {
+      let format = "[day padding:none]. [month repr:long] [year]"
+      if document.date == auto {
+        datetime.today().display(format)
+      } else {
+        document.date.display(format)
+      }
+    }
   }
 
   set text(font: font, hyphenate: false)


### PR DESCRIPTION
When either of `sender.name`, `subject` or `date` is not given, it falls back to document metadata respectively.

https://typst.app/docs/reference/model/document/

In the case of fallback date selection, the month names are still printed in english.
The reason for this is that I did not want to introduce a new dependency for this.