### PR TITLE
Make the closing signature unbreakable in the template

### DIFF
--- a/template/src/main.typ
+++ b/template/src/main.typ
@@ -40,9 +40,11 @@ und bitte Sie, die Abschreibung anzuerkennen.
 
 Anbei erhalten Sie eine Kopie der Rechnung des Gerätes.
 
-Mit freundlichen Grüßen
-#v(1cm)
-Anja Ahlsen
+#block(breakable: false)[
+  Mit freundlichen Grüßen
+  #v(1cm)
+  Anja Ahlsen
+]
 
 #v(1fr)
 *Anlagen:*


### PR DESCRIPTION
I had the issue that the letter ended around the page end.

I found that at least he closing signature should _never_ be broken, as that is _never_ useful, I guess. I mean you need to put your signature there…

And even if one removes the vertical space there, also without a signature it is quite useless to have a line break between the greeting and your name. :wink: 

Only thing is one may argue it will look ugly anyway, if you only have the signature on one page. Thus, I (newby) also found and placed a `#pagebreak(weak: true)` somewhere a paragraph before, which makes it look quite good. That cannot be done generically in a template though.