### PR TITLE
Feature: Add letterhead header and footer

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -51,6 +51,9 @@
 /// - header (content, none): The header that will be displayed at the top of the first page.
 /// - footer (content, none): The footer that will be displayed at the bottom of the first page. It automatically grows upwords depending on its body. Make sure to leave enough space in the page margins.
 /// 
+/// - letterhead-header (content, none): Custom letterhead header for optional corporate design displayed at the top of every page. Use place() to not affect existing content.
+/// - letterhead-footer (content, none): Custom letterhead footer for optional corporate design displayed at the bottom of every page. Use place() to not affect existing content.
+/// 
 /// - folding-marks (boolean): The folding marks that will be displayed at the left margin.
 /// - hole-mark (boolean): The hole mark that will be displayed at the left margin.
 /// 
@@ -98,6 +101,9 @@
   
   header: none,
   footer: none,
+  
+  letterhead-header: none,
+  letterhead-footer: none,
   
   folding-marks: true,
   hole-mark: true,
@@ -158,7 +164,7 @@
         ))
       }
     },
-    
+    header: letterhead-header,
     footer-descent: 0%,
     footer: context {
       show: pad.with(top: 12pt, bottom: 12pt)
@@ -166,6 +172,7 @@
       let current-page = counter(page).get().first()
       let page-count = counter(page).final().first()
       
+      letterhead-footer
       grid(
         columns: 1fr,
         rows: (0.65em, 1fr),
@@ -430,6 +437,9 @@
 /// - header (auto, content, none): The header that will be displayed at the top of the first page. If header is set to _auto_, a default header will be generaded instead.
 /// - footer (content, none): The footer that will be displayed at the bottom of the first page. It automatically grows upwords depending on its body. Make sure to leave enough space in the page margins.
 /// 
+/// - letterhead-header (content, none): Custom letterhead header for optional corporate design displayed at the top of every page. Use place() to not affect existing content.
+/// - letterhead-footer (content, none): Custom letterhead footer for optional corporate design displayed at the bottom of every page. Use place() to not affect existing content.
+/// 
 /// - folding-marks (boolean): The folding marks that will be displayed at the left margin.
 /// - hole-mark (boolean): The hole mark that will be displayed at the left margin.
 /// 
@@ -492,7 +502,10 @@
   
   header: auto,
   footer: none,
-
+  
+  letterhead-header: none,
+  letterhead-footer: none,
+  
   folding-marks: true,
   hole-mark: true,
   
@@ -580,7 +593,10 @@
     
     header: header,
     footer: footer,
-
+    
+    letterhead-header: letterhead-header,
+    letterhead-footer: letterhead-footer,
+    
     folding-marks: folding-marks,
     hole-mark: hole-mark,
     


### PR DESCRIPTION
Basically every company has their own letterhead design, which is used for official communications. This letter template works great if printed on paper that already has the letterhead on it. However, since most documents are now sent digitally, a feature should exist that allows someone to add their own letterhead to letters created with this template.

Since `header` and `footer` are already used variables for a different purpose, this PR adds additional `letterhead-header` and `letterhead-footer` to allow the user to add their desired letterhead stylings. The user should then use `place()` to position, e.g. their logo, at the desired location. Appropriate documentation has been added.